### PR TITLE
Issue: ansible script to support installation of sfagent on systems with arm architecture

### DIFF
--- a/playbooks/roles/sfagent/tasks/install.yml
+++ b/playbooks/roles/sfagent/tasks/install.yml
@@ -104,7 +104,7 @@
 - name: unzip sfagent
   shell: | 
     if [ "{{ ansible_architecture }}" != "aarch64" ] ; then
-      tar -zxvf /opt/sfagent/sfagent*linux_{{ ansible_architecture }}.tar.gz 
+      tar -zxvf /opt/sfagent/sfagent*linux_{{ ansible_architecture }}.tar.gz >/dev/null 
     elif [ "{{ ansible_architecture }}" == "aarch64" ] ; then
       tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
     fi

--- a/playbooks/roles/sfagent/tasks/install.yml
+++ b/playbooks/roles/sfagent/tasks/install.yml
@@ -16,12 +16,31 @@
   
 - name: download fluentbit for systemd
   shell: |
-    curl https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+    if [ {{ansible_architecture}} != "aarch64" ] ; then
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
         | grep -w "browser_download_url"|grep "download/fluentbit" \
         | head -n 1 \
         | cut -d":" -f 2,3 \
         | tr -d '"' \
-        | xargs wget -q -N && mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/ 
+        | xargs wget -q
+    elif [ {{ansible_architecture}} = "aarch64" ]; then
+        VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+        if [ $VERSION = "22.04" ] ; then
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/ubuntu22-fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+        else
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+        fi
+    fi
   args:
     chdir: /tmp
     warn: false
@@ -34,14 +53,14 @@
         | head -n 1 \
         | cut -d":" -f 2,3 \
         | tr -d '"' \
-        | xargs wget -q -N && mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/
+        | xargs wget -q
   args:
     chdir: /tmp
     warn: false
   when: ansible_service_mgr != 'systemd'
 
 - name: Install fluent-bit 
-  shell: tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
+  shell: mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/ && tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
   args:
     chdir: /tmp
     warn: false
@@ -83,10 +102,18 @@
     warn: false
 
 - name: unzip sfagent
-  shell: tar -zxvf /opt/sfagent/sfagent*linux_{{ansible_architecture}}.tar.gz && rm sfagent*linux_* checksum*
+  shell: | 
+    if [ "{{ ansible_architecture }}" != "aarch64" ] ; then
+      tar -zxvf /opt/sfagent/sfagent*linux_{{ ansible_architecture }}.tar.gz 
+    elif [ "{{ ansible_architecture }}" == "aarch64" ] ; then
+      tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
+    fi
+    rm sfagent*linux_* checksum*
   args:
     chdir: /opt/sfagent/
     warn: false
+    executable: /bin/bash
+  become: true
 
 - include_vars: ../config-params.yml
   ignore_errors: true
@@ -276,4 +303,6 @@
   ansible.builtin.debug:
     msg:
     -  sfagent installed successfully.
+
+
 

--- a/playbooks/roles/sfagent/tasks/upgrade.yml
+++ b/playbooks/roles/sfagent/tasks/upgrade.yml
@@ -15,12 +15,31 @@
   block:
     - name: download fluentbit for systemd
       shell: |
-        curl https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
-            | grep -w "browser_download_url"|grep fluentbit \
-            | head -n 1 \
-            | cut -d":" -f 2,3 \
-            | tr -d '"' \
-            | xargs wget -q -N && mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/ 
+            if [ {{ansible_architecture}} != "aarch64" ] ; then
+                curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                | grep -w "browser_download_url"|grep "download/fluentbit" \
+                | head -n 1 \
+                | cut -d":" -f 2,3 \
+                | tr -d '"' \
+                | xargs wget -q
+            elif [ {{ansible_architecture}} = "aarch64" ]; then
+                VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+                if [ $VERSION = "22.04" ] ; then
+                    curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                    | grep -w "browser_download_url"|grep "download/ubuntu22-fluent-bit-arm" \
+                    | head -n 1 \
+                    | cut -d":" -f 2,3 \
+                    | tr -d '"' \
+                    | xargs wget -q
+                else
+                    curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                    | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
+                    | head -n 1 \
+                    | cut -d":" -f 2,3 \
+                    | tr -d '"' \
+                    | xargs wget -q
+                fi
+            fi
       args:
         chdir: /tmp
         warn: false
@@ -40,7 +59,7 @@
       when: ansible_service_mgr != 'systemd'
 
     - name: Install fluent-bit 
-      shell: tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
+      shell: mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/  && tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
       args:
         chdir: /tmp
         warn: false
@@ -82,10 +101,18 @@
         warn: false
 
     - name: unzip sfagent
-      shell: tar -zxvf /opt/sfagent/sfagent*linux_{{ansible_architecture}}.tar.gz && rm sfagent*linux_* checksum*
+      shell: |
+            if [ "{{ ansible_architecture }}" != "aarch64" ] ; then
+              tar -zxvf /opt/sfagent/sfagent*linux_{{ ansible_architecture }}.tar.gz >/dev/null 
+            elif [ "{{ ansible_architecture }}" == "aarch64" ] ; then
+              tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
+            fi
+            rm sfagent*linux_* checksum*
       args:
         chdir: /opt/sfagent/
         warn: false
+        executable: /bin/bash
+      become: true
 
     - include_vars: ../config-params.yml
       ignore_errors: true
@@ -286,12 +313,31 @@
 
     - name: upgrading fluentbit for systemd
       shell: |
-        curl https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
-            | grep -w "browser_download_url"|grep fluentbit \
-            | head -n 1 \
-            | cut -d":" -f 2,3 \
-            | tr -d '"' \
-            | xargs wget -q -N 
+            if [ {{ansible_architecture}} != "aarch64" ] ; then
+                curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                | grep -w "browser_download_url"|grep "download/fluentbit" \
+                | head -n 1 \
+                | cut -d":" -f 2,3 \
+                | tr -d '"' \
+                | xargs wget -q
+            elif [ {{ansible_architecture}} = "aarch64" ]; then
+                VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+                if [ $VERSION = "22.04" ] ; then
+                    curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                    | grep -w "browser_download_url"|grep "download/ubuntu22-fluent-bit-arm" \
+                    | head -n 1 \
+                    | cut -d":" -f 2,3 \
+                    | tr -d '"' \
+                    | xargs wget -q
+                else
+                    curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+                    | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
+                    | head -n 1 \
+                    | cut -d":" -f 2,3 \
+                    | tr -d '"' \
+                    | xargs wget -q
+                fi
+            fi
       args:
         chdir: /tmp
         warn: false
@@ -311,7 +357,7 @@
       when: ansible_service_mgr != 'systemd'
 
     - name: upgrade fluent-bit 
-      shell: tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
+      shell: mkdir -p /opt/td-agent-bit/bin && mkdir -p /etc/td-agent-bit/ && tar -zxvf fluentbit.tar.gz >/dev/null && mv -f fluent-bit /opt/td-agent-bit/bin/td-agent-bit && mv -f GeoLite2-City.mmdb {{TDAGENTCONFDIR}} && mv -f uaparserserver /opt/td-agent-bit/bin/ && mv -f url-normalizer /opt/td-agent-bit/bin/ && mv -f td-agent-bit.conf /etc/td-agent-bit/  && rm fluentbit.tar.gz* && rm td-agent-bit.service
       args:
         chdir: /tmp
         warn: false
@@ -344,7 +390,11 @@
       
     - name: upgrade sfagent started
       shell: |
-        tar -zxvf sfagent*linux_{{ansible_architecture}}.tar.gz >/dev/null 
+        if [ "{{ ansible_architecture }}" != "aarch64" ] ; then
+          tar -zxvf /opt/sfagent/sfagent*linux_{{ ansible_architecture }}.tar.gz >/dev/null 
+        elif [ "{{ ansible_architecture }}" == "aarch64" ] ; then
+          tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
+        fi 
         mkdir -p {{AGENTDIR}}/normalization
         mkdir -p {{AGENTDIR}}/certs
         mkdir -p {{AGENTDIR}}/mappings
@@ -359,6 +409,8 @@
       args:
         chdir: /tmp
         warn: false
+        executable: /bin/bash
+      become: true
 
     - name: Copying back config.yaml and customer scripts
       shell: |
@@ -394,3 +446,4 @@
         msg:
         -  sfagent upgradeded successfully.
   when: agentdir.stat.exists
+


### PR DESCRIPTION
Issue: ansible script to support installation of sfagent on systems with arm architecture
Root cause: enhancement
Changes made: i) Added check to download and install fluentbit as per architecture during installation and upgrade
              ii) Added check to download and install sfagent as per architecture during installation and upgrade
Testcases:
i) sfagent installation via ansible script on amd64(x86_64) architecture - sfagent downloaded and installed successfully, correct fluentbit binary installed
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/7a2e3b7f-de09-4783-bf9a-a570710c93d4)
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/b9313c6a-f4f8-4cab-8f00-d2fc51b7cb45)
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/a370788c-5936-4605-b2cf-83f554a9a37c)


ii) sfagent installation via ansible script on amd64(aarch64) architecture - sfagent downloaded and installed successfully, correct fluentbit binary installed
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/b846a7cb-fb88-4b92-9939-d177e97af513)
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/827cd63a-83a0-45e9-a664-779c720484a1)
![image](https://github.com/snappyflow/ansible-role-apm-agent/assets/110602101/3eb636c8-8151-4454-ac5e-1216578967b0)



